### PR TITLE
Fix user ID handling in invoice creation

### DIFF
--- a/backend/infrastructure/django/repositories/invoice_repository.py
+++ b/backend/infrastructure/django/repositories/invoice_repository.py
@@ -4,7 +4,6 @@ from datetime import date
 from typing import Optional, List
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
-from django.contrib.auth import get_user_model
 from domain.repositories.interfaces.invoice_repository import InvoiceRepository
 from domain.models.invoice import Invoice as DomainInvoice
 from domain.exceptions import InvalidInvoiceError
@@ -30,15 +29,13 @@ class DjangoInvoiceRepository(InvoiceRepository):
         user_id: int
     ) -> DjangoInvoice:
         """Convert domain model to Django model."""
-        user_model = get_user_model()
-        user = user_model.objects.get(id=user_id)
         return DjangoInvoice(
             invoice_number=domain_invoice.invoice_number,
             amount=domain_invoice.amount,
             due_date=domain_invoice.due_date,
             file_path=domain_invoice.file_path,
             status=domain_invoice.status,
-            uploaded_by_id=user
+            uploaded_by_id=user_id
         )
 
     def save(self, invoice: DomainInvoice, user_id: int) -> DomainInvoice:


### PR DESCRIPTION
Update `_to_django` method to use user ID instead of User object

* Remove the line that fetches the user object using `get_user_model`
* Assign `user_id` directly to `uploaded_by_id` in the `_to_django` method
* Ensure the `save` method correctly handles the user ID

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Billify-VOF/billify-prototype/pull/4?shareId=a2090ac6-6abf-4ad5-8be3-db9f85927789).