### PR TITLE
Fix PDF footer to stick to bottom when zoomed in

### DIFF
--- a/frontend/components/PDFViewerWrapper.tsx
+++ b/frontend/components/PDFViewerWrapper.tsx
@@ -133,37 +133,41 @@ const PDFViewer = ({ filePath }: { filePath: string }) => {
             <p className="text-sm">Click to select a PDF file</p>
           </div>
         ) : (
-          <div 
-            style={{ 
-              transform: `translate(${position.x}px, ${position.y}px)`,
-              transition: isDragging ? 'none' : 'transform 0.1s',
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center'
-            }}
-          >
-            <Document
-              file={pdfUrl}
-              onLoadSuccess={onDocumentLoadSuccess}
-              onLoadError={(error) => {
-                console.error('PDF Load Error:', error);
-                setError(error.message);
-              }}
-              loading={<div className="text-gray-500">Loading PDF...</div>}
-            >
-              <Page 
-                pageNumber={pageNumber} 
-                width={400}
-                scale={scale}
-                renderTextLayer={true}
-                renderAnnotationLayer={true}
-                loading={<div className="text-gray-500">Loading page...</div>}
-              />
-            </Document>
+          <>
+            <div className="flex-1 overflow-auto">
+              <div 
+                style={{ 
+                  transform: `translate(${position.x}px, ${position.y}px)`,
+                  transition: isDragging ? 'none' : 'transform 0.1s',
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center'
+                }}
+              >
+                <Document
+                  file={pdfUrl}
+                  onLoadSuccess={onDocumentLoadSuccess}
+                  onLoadError={(error) => {
+                    console.error('PDF Load Error:', error);
+                    setError(error.message);
+                  }}
+                  loading={<div className="text-gray-500">Loading PDF...</div>}
+                >
+                  <Page 
+                    pageNumber={pageNumber} 
+                    width={400}
+                    scale={scale}
+                    renderTextLayer={true}
+                    renderAnnotationLayer={true}
+                    loading={<div className="text-gray-500">Loading page...</div>}
+                  />
+                </Document>
+              </div>
+            </div>
             {numPages && numPages > 1 && (
-              <div className="flex-shrink-0 flex justify-between items-center p-4 bg-white bg-opacity-90">
+              <div className="flex-shrink-0 flex justify-between items-center p-4 bg-white border-t border-gray-200">
                 <button
                   onClick={() => setPageNumber(prev => Math.max(prev - 1, 1))}
                   disabled={pageNumber <= 1}
@@ -183,7 +187,7 @@ const PDFViewer = ({ filePath }: { filePath: string }) => {
                 </button>
               </div>
             )}
-          </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
Fixes #33

Fix the 'next page' and 'previous page' footer in the PDF view to stick to the bottom of the view when zoomed in.

* Modify `frontend/components/PDFViewerWrapper.tsx` to wrap the PDF viewer and the footer in a container with `display: flex` and `flex-direction: column`.
* Set the PDF viewer to `flex: 1` to take up the remaining space.
* Set the footer to `flex-shrink: 0` to ensure it doesn't shrink.
* Adjust the footer's class to remove absolute positioning and ensure it is part of the flex container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Billify-VOF/billify-prototype/pull/34?shareId=901940e0-c14f-4c1d-bf17-5d4736f1796d).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated layout and styling of PDF viewer component
	- Refined flex container and pagination control positioning
	- Enhanced responsiveness with additional overflow handling for PDF rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->