### PR TITLE
Fix upload popup closing on outside click

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -197,6 +197,7 @@ const BillifyDashboard = () => {
                             ? (selectedFile ? 'w-[300px] h-[180px] p-3' : 'w-[300px] h-[140px] p-3')
                             : 'w-[1000px] h-[600px] p-6'
                         } resize-none overflow-auto`}
+                        onInteractOutside={(e) => e.preventDefault()} // Prevent closing on outside clicks
                       >
                         {!uploadedInvoiceData && (
                           <div className="space-y-4">

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -41,6 +41,7 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 sm:rounded-lg",
         className
       )}
+      onInteractOutside={(e) => e.preventDefault()} // Prevent closing on outside clicks
       {...props}
     >
       {children}


### PR DESCRIPTION
Fixes #37

Update the upload window popup to prevent closing when clicking outside of the popup window.

* **frontend/app/dashboard/page.tsx**
  - Add `onInteractOutside` prop to `DialogContent` component to prevent closing on outside clicks.

* **frontend/components/ui/dialog.tsx**
  - Add `onInteractOutside` prop to `DialogContent` component to prevent closing on outside clicks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Billify-VOF/billify-prototype/pull/38?shareId=a8534438-cee7-4afe-b88f-c96c42af9b85).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dialog interaction by preventing unintended closure when users interact outside the dialog
	- Improved user experience for dialog interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->